### PR TITLE
Moved distribution close to being "CPANTS clean"

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl module WebService::Lob
 
 0.01?? 2014-12-?? AANARI
     - Added Changes file
+    - Added abstract section to pod (=head1 NAME), so module will appear
+      right in MetaCPAN etc.
 
 0.0107 2014-11-07 AANARI
     - Updated to use WebService::Client

--- a/Changes
+++ b/Changes
@@ -1,10 +1,11 @@
 Revision history for Perl module WebService::Lob
 
-0.01?? 2014-12-?? AANARI
+0.0108 2014-12-?? AANARI
     - Added Changes file
     - Added abstract section to pod (=head1 NAME), so module will appear
       right in MetaCPAN etc.
     - Added a SEE ALSO section to pod, with link to lob.com docs page
+    - Specified min perl version as 5.012 in code and metadata
 
 0.0107 2014-11-07 AANARI
     - Updated to use WebService::Client

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl module WebService::Lob
     - Added Changes file
     - Added abstract section to pod (=head1 NAME), so module will appear
       right in MetaCPAN etc.
+    - Added a SEE ALSO section to pod, with link to lob.com docs page
 
 0.0107 2014-11-07 AANARI
     - Updated to use WebService::Client

--- a/Changes
+++ b/Changes
@@ -1,0 +1,20 @@
+Revision history for Perl module WebService::Lob
+
+0.01?? 2014-12-?? AANARI
+    - Added Changes file
+
+0.0107 2014-11-07 AANARI
+    - Updated to use WebService::Client
+    - Switch to Method::Signatures to work with older Perls
+    - Fixed dist and weaver for travis
+
+0.0105 2014-08-23 AANARI
+    - Remove TrustPod and Pod Coverage for now
+    - Fixed pod, bumped version
+    - Improved Travis, dzil, and weaver config
+    - use aliased exception class names (@ironcamel++)
+    - Removed aliased to fix dzil, bumped version
+
+0.0104 2014-08-22 AANARI
+    - First release to CPAN
+

--- a/Changes
+++ b/Changes
@@ -5,7 +5,7 @@ Revision history for Perl module WebService::Lob
     - Added abstract section to pod (=head1 NAME), so module will appear
       right in MetaCPAN etc.
     - Added a SEE ALSO section to pod, with link to lob.com docs page
-    - Specified min perl version as 5.012 in code and metadata
+    - Specified min perl version as 5.8.1 in code and metadata
 
 0.0107 2014-11-07 AANARI
     - Updated to use WebService::Client

--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires "Throwable::Error" => "0";
 requires "WebService::BaseClientRole" => "0.0004";
 requires "WebService::Client" => "0";
 requires "aliased" => "0";
+requires "perl" => "5.012";
 
 on 'test' => sub {
   requires "Exporter" => "0";
@@ -14,7 +15,6 @@ on 'test' => sub {
   requires "Storable" => "0";
   requires "Test::Modern" => "0";
   requires "Test::More" => "0";
-  requires "perl" => "5.006";
   requires "strict" => "0";
   requires "warnings" => "0";
 };

--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@ requires "Throwable::Error" => "0";
 requires "WebService::BaseClientRole" => "0.0004";
 requires "WebService::Client" => "0";
 requires "aliased" => "0";
-requires "perl" => "5.012";
+requires "perl" => "5.008";
 
 on 'test' => sub {
   requires "Exporter" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ copyright_holder = Ali Anari
 copyright_year   = 2014
 abstract = Lob API Bindings
 
-version = 0.0107
+version = 0.0108
 
 [TravisYML]
 notify_email = 1

--- a/lib/WebService/Lob.pm
+++ b/lib/WebService/Lob.pm
@@ -218,6 +218,10 @@ The address you entered was found but more information is needed to match to a s
 
 =back
 
+=head1 SEE ALSO
+
+L<https://lob.com/docs> - the API docs for L<lob.com>
+
 =cut
 
 1;

--- a/lib/WebService/Lob.pm
+++ b/lib/WebService/Lob.pm
@@ -52,6 +52,10 @@ method verify_address(
     return $result->{address};
 }
 
+=head1 NAME
+
+WebService::Lob - interface to API for lob.com (printing and mailing service)
+
 =head1 SYNOPSIS
 
     use WebService::Lob;

--- a/lib/WebService/Lob.pm
+++ b/lib/WebService/Lob.pm
@@ -1,6 +1,6 @@
 package WebService::Lob;
 
-use 5.012;
+use 5.008001;
 use Moo;
 with 'WebService::Client';
 

--- a/lib/WebService/Lob.pm
+++ b/lib/WebService/Lob.pm
@@ -1,4 +1,6 @@
 package WebService::Lob;
+
+use 5.012;
 use Moo;
 with 'WebService::Client';
 

--- a/lib/WebService/Lob/Exception/AddressMissingInformation.pm
+++ b/lib/WebService/Lob/Exception/AddressMissingInformation.pm
@@ -1,4 +1,5 @@
 package WebService::Lob::Exception::AddressMissingInformation;
+
 use Moo;
 extends 'Throwable::Error';
 

--- a/lib/WebService/Lob/Exception/AddressNotFound.pm
+++ b/lib/WebService/Lob/Exception/AddressNotFound.pm
@@ -1,4 +1,5 @@
 package WebService::Lob::Exception::AddressNotFound;
+
 use Moo;
 extends 'Throwable::Error';
 


### PR DESCRIPTION
Hi Ali,

This has a number of minor changes to get the distribution following various CPAN conventions:
- Added a Changes file, which follows conventions in CPAN::Changes::Spec
- Added an abstract to the pod
- Specified min version of perl (based on perlver, which is in the Perl::MinimumVersion dist)
- Added a SEE ALSO section to the pod

The only thing CPANTS doesn't like now is the fact that the CPAN distribution doesn't contain a README. Is there a dzil plugin that will render your README.md as README, to include in the release?

Cheers,
Neil
